### PR TITLE
Fix debug command naming

### DIFF
--- a/SystemNameCalculator/Program.cs
+++ b/SystemNameCalculator/Program.cs
@@ -102,7 +102,7 @@ namespace SystemNameCalculator
                     Logging.PrintError("\nCould not parse input! Are you sure you typed the command correctly?\n");
                 }
             }
-            else if (vars[0] == "debug")
+            else if (vars[0] == "/debug")
             {
                 Debug = !Debug;
                 Logging.Print("Toggled debug mode!");


### PR DESCRIPTION
It should either accept `/debug` here or have `debug` instead of `debug` in the command list above